### PR TITLE
Adding dns delay to wait host registration before adding it to the mongo cluster

### DIFF
--- a/mongodb3/libraries/users.rb
+++ b/mongodb3/libraries/users.rb
@@ -18,7 +18,7 @@ class Chef::Recipe::UserHelper
         end
         
         db = client.use('admin')
-        roles = [{'role': 'userAdminAnyDatabase', 'db': 'admin'}, {'role': 'clusterAdmin', 'db': 'admin'}]
+        roles = [{'role': 'userAdminAnyDatabase', 'db': 'admin'}, {'role': 'clusterAdmin', 'db': 'admin'}, {'role': 'dbAdminAnyDatabase', 'db': 'admin'}, {'role': 'readWriteAnyDatabase', 'db': 'admin'}]
         create_user(username, password, roles, db, client)
 
     end


### PR DESCRIPTION
Adding dns delay to wait host registration before adding it to the mongo cluster